### PR TITLE
Updating GA to Go 1.21 to fix errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.1'
+          go-version: '1.21'
       - name: run unit tests
         run: make test
       - name: build a local artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.1'
+          go-version: '1.21'
       - name: Compile all versions
         run: make release VERSION=${GITHUB_REF_NAME}
       - name: Generate SBOM


### PR DESCRIPTION
The Github Actions workflows are failing because 1.20.1 doesn't support the toolchain directive.