### PR TITLE
Bumping Go to version 1.24 (latest)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
       - name: run unit tests
         run: make test
       - name: build a local artifact

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
       - name: Compile all versions
         run: make release VERSION=${GITHUB_REF_NAME}
       - name: Generate SBOM

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/scottbrown/dumpcft
 
-go 1.21
-
-toolchain go1.23.5
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 golang.org/x/exp v0.0.0-20230304125523-9ff063c70017 h1:3Ea9SZLCB0aRIhSEjM+iaGIlzzeDJdpi579El/YIhEE=
 golang.org/x/exp v0.0.0-20230304125523-9ff063c70017/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
# What Changed

This pull request includes updates to the Go version used in the project. The changes ensure that the project uses Go version 1.24 across different workflows and configuration files.

Updates to Go version:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL14-R14): Updated the Go version from 1.21 to 1.24 in the CI workflow.
* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL18-R18): Updated the Go version from 1.21 to 1.24 in the release workflow.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version to 1.24 and removed the outdated toolchain specification.This change bumps the Go version to the latest stable (v1.24).

# Why it Changed

I'm keeping the project up-to-date with the latest stable version of Go to benefit from the latest features, improvements, and security updates provided by the Go language maintainers.